### PR TITLE
IIS Webserver role (#2)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -14,6 +14,8 @@ mod 'puppet-archive', '4.6.0'
 mod 'puppetlabs-pwshlib', '0.8.0'
 mod 'puppetlabs-powershell', '5.0.0'
 mod 'puppetlabs-chocolatey', '6.0.0'
+mod 'puppetlabs-iis', '8.0.0'
+mod 'puppetlabs-reboot', '4.0.2'
 
 # Modules from Git
 # Examples: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd#examples

--- a/site-modules/profile/manifests/platform/baseline/third_party_software/windows.pp
+++ b/site-modules/profile/manifests/platform/baseline/third_party_software/windows.pp
@@ -16,7 +16,12 @@ class profile::platform::baseline::third_party_software::windows {
   }
 
   package { '7zip':
-    ensure   => latest,
-    provider => chocolatey,
+    ensure   => 'latest',
+    provider => 'chocolatey',
+    notify => Reboot['after_run'],
+  }
+
+  reboot { 'after_run':
+    apply  => finished,
   }
 }

--- a/site-modules/profile/manifests/platform/windows/webserver/iis_server.pp
+++ b/site-modules/profile/manifests/platform/windows/webserver/iis_server.pp
@@ -1,0 +1,49 @@
+class profile::platform::windows::webserver::iis_server {
+  # Minimal features necessary to ensure an IIS installation
+  $iis_features = ['Web-WebServer','Web-Scripting-Tools']
+  $iss_folders_group = 'IIS_IUSRS'
+
+  iis_feature { $iis_features:
+    ensure => 'present',
+  }
+
+  # Delete the default website to prevent a port binding conflict.
+  iis_site {'Default Web Site':
+    ensure  => absent,
+    require => Iis_feature['Web-WebServer'],
+  }
+
+  iis_site { 'minimal':
+    ensure          => 'started',
+    physicalpath    => 'c:\\inetpub\\minimal',
+    applicationpool => 'DefaultAppPool',
+    require         => [
+      File['minimal'],
+      Iis_site['Default Web Site']
+    ],
+  }
+
+  file { 'minimal':
+    ensure => 'directory',
+    path   => 'c:\\inetpub\\minimal',
+  }
+
+  # Set Permissions
+  acl { 'c:\\inetpub\\minimal':
+    permissions => [
+      { identity => $iss_folders_group, rights => ['read', 'execute']},
+    ],
+  }
+
+  # Adds basic website
+  $install_path = 'C:/inetpub/minimal'
+  $html_file_source = 'https://gist.githubusercontent.com/dylanratcliffe/af0e24303d241b888152bd1cd7c9063d/raw/ad273bebc01c6dac176da7a5f3c38c4d9a584521/index.html'
+
+  file { "${install_path}/index.html":
+    path        => "${install_path}/index.html",
+    ensure      => 'present',
+    source      => $html_file_source,
+    group       => $iss_folders_group,
+    mode        => '0555',
+  }
+}

--- a/site-modules/role/manifests/webserver.pp
+++ b/site-modules/role/manifests/webserver.pp
@@ -1,7 +1,4 @@
 class role::webserver {
-
-  #This role would be made of all the profiles that need to be included to make a webserver work
-  #All roles should include the base profile
-  include profile::base
-
+  include profile::platform::baseline
+  include profile::platform::windows::webserver::iis_server
 }


### PR DESCRIPTION
* adds the puppetlabs-iis module

* adds profiles to the webserver role

* adds functionality to the iis_server profile

* enforces basic website for IIS

* adds puppetlabs-reboot

* adds class block for choco debugging purposes

* uses a file resource to download the html file

* sets permissions for the IIS website folder