### PR TITLE
adds reidmv-taskplan to the Puppetfile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,6 +17,9 @@ mod 'puppetlabs-chocolatey', '6.0.0'
 mod 'puppetlabs-iis', '8.0.0'
 mod 'puppetlabs-reboot', '4.0.2'
 
+# For running a plan via task to avoid hitting orchestrator
+mod 'reidmv-taskplan', '0.2.0'
+
 # Modules from Git
 # Examples: https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd#examples
 #mod 'apache',


### PR DESCRIPTION
### Changes

Adding the `taskplan` module [from the Forge](https://forge.puppet.com/modules/reidmv/taskplan/)
