### PR TITLE
adds a bolt-project.yaml with a simple test plan

### DIFF
--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -1,0 +1,2 @@
+---
+name: solarch

--- a/plans/hiplan.pp
+++ b/plans/hiplan.pp
@@ -1,0 +1,7 @@
+plan solarch::hiplan (
+  String $message,
+) {
+
+  notice("Ran solarch::hiplan, with the message: ${message}")
+
+}

--- a/tasks/infrastatus.json
+++ b/tasks/infrastatus.json
@@ -1,0 +1,15 @@
+{
+    "supports_noop": false,
+    "description": "Runs puppet infra status and returns the output",
+    "parameters": {
+      "format": {
+        "type": "Enum[json,text]",
+        "description": "The type of output to return",
+        "default": "text"
+      }
+    },
+    "input_method": "environment",
+    "implementations": [
+      {"name": "infrastatus.sh"}
+    ]
+  }

--- a/tasks/infrastatus.sh
+++ b/tasks/infrastatus.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+if [[ $(id -un) != 'root' ]]; then 
+  echo "must be root"
+  exit 1
+fi
+
+
+case $PT_format in
+  json)
+    data=$(/opt/puppetlabs/bin/puppet infra status --format=json) 
+    echo "{\"output\": ${data} }" 
+    ;;
+  *)
+    /opt/puppetlabs/bin/puppet infra status
+    ;;
+esac 


### PR DESCRIPTION
### Changes

Adding a `bolt-project.yaml` in the control-repo with the intention to test a couple of plans from the PE console via the `taskplan`module